### PR TITLE
Remove reference to obsolete district office table

### DIFF
--- a/GECO/Facility/Summary.aspx
+++ b/GECO/Facility/Summary.aspx
@@ -53,12 +53,6 @@
                 </td>
             </tr>
             <tr>
-                <th scope="row">Office:</th>
-                <td>
-                    <asp:Label ID="lblOffice" runat="server"></asp:Label>
-                </td>
-            </tr>
-            <tr>
                 <th scope="row">Longitude:</th>
                 <td>
                     <asp:Label ID="lblLongitude" runat="server"></asp:Label>

--- a/GECO/Facility/Summary.aspx.designer.vb
+++ b/GECO/Facility/Summary.aspx.designer.vb
@@ -95,15 +95,6 @@ Partial Public Class FacilitySummary
     Protected WithEvents hlDistrict As Global.System.Web.UI.WebControls.HyperLink
 
     '''<summary>
-    '''lblOffice control.
-    '''</summary>
-    '''<remarks>
-    '''Auto-generated field.
-    '''To modify move field declaration from designer file to code-behind file.
-    '''</remarks>
-    Protected WithEvents lblOffice As Global.System.Web.UI.WebControls.Label
-
-    '''<summary>
     '''lblLongitude control.
     '''</summary>
     '''<remarks>

--- a/GECO/Facility/Summary.aspx.vb
+++ b/GECO/Facility/Summary.aspx.vb
@@ -87,7 +87,6 @@ Partial Class FacilitySummary
                 lblLongitude.Text = longitude.ToString()
                 lblCounty.Text = GetNullableString(dr.Item("strCountyName"))
                 lblDistrict.Text = GetNullableString(dr.Item("strDistrictName"))
-                lblOffice.Text = GetNullableString(dr.Item("strOfficeName"))
 
                 If Convert.IsDBNull(dr.Item("strDistrictResponsible")) OrElse
                     dr.Item("strDistrictResponsible").ToString <> "True" Then


### PR DESCRIPTION
Table `LOOKUPDISTRICTOFFICE` gets dropped and view `VW_APBFACILITYLOCATION` gets modified. 

View is used in both GECO & IAIP, but only GECO used data from the obsolete table.

ref gaepdit/airbranch-db#5
closes #302 