### PR TITLE
Check FAX number string length before calling Substring method

### DIFF
--- a/GECO/AnnualFees/Default.aspx.vb
+++ b/GECO/AnnualFees/Default.aspx.vb
@@ -63,7 +63,7 @@ Partial Class AnnualFees_Default
             feeYear = Nothing
         Else
             feeYear = CInt(ddlFeeYear.SelectedItem.Text)
-            feeYearCompleted = ddlFeeYear.SelectedValue.SubstringFrom(4) = "1"
+            feeYearCompleted = ddlFeeYear.SelectedValue.Substring(4) = "1"
         End If
     End Sub
 

--- a/GECO/ES/Form.aspx.vb
+++ b/GECO/ES/Form.aspx.vb
@@ -1,4 +1,4 @@
-﻿Imports System.Data.SqlClient
+Imports System.Data.SqlClient
 Imports System.DateTime
 Imports System.Math
 Imports GECO.GecoModels
@@ -285,7 +285,11 @@ Partial Class es_form
             End If
             If Not Convert.IsDBNull(dr("strContactFaxNumber")) Then
                 ContactFaxNumber = dr.Item("strContactFaxNumber").ToString
-                txtFaxNbr.Text = ContactFaxNumber.Substring(0, 10)
+                If ContactFaxNumber.Length > 10 Then
+                    txtFaxNbr.Text = ContactFaxNumber.Substring(0, 10)
+                Else
+                    txtFaxNbr.Text = ContactFaxNumber
+                End If
             End If
             If Convert.IsDBNull(dr("strContactEmail")) Then
                 txtContactEmail.Text = ""
@@ -507,7 +511,11 @@ Partial Class es_form
             End If
             If Not Convert.IsDBNull(dr("strContactFaxNumber")) Then
                 ContactFaxNumber = dr.Item("strContactFaxNumber").ToString
-                txtFaxNbr.Text = ContactFaxNumber.Substring(0, 10)
+                If ContactFaxNumber.Length > 10 Then
+                    txtFaxNbr.Text = ContactFaxNumber.Substring(0, 10)
+                Else
+                    txtFaxNbr.Text = ContactFaxNumber
+                End If
             End If
             If Convert.IsDBNull(dr("strContactEmail")) Then
                 txtContactEmail.Text = ""

--- a/GECO/TN/Default.aspx.vb
+++ b/GECO/TN/Default.aspx.vb
@@ -61,14 +61,14 @@ Partial Class TN_Default
                     lblEPDTelephone.Text = "404-363-7000 (ask For Source Monitoring Unit)"
                 Else
                     EPDTelephone = CStr(dr.Item("STRPHONE"))
-                    lblEPDTelephone.Text = EPDTelephone.Substring(0, 3) & "-" & EPDTelephone.Substring(3, 3) & "-" & EPDTelephone.SubstringFrom(6)
+                    lblEPDTelephone.Text = EPDTelephone.Substring(0, 3) & "-" & EPDTelephone.Substring(3, 3) & "-" & EPDTelephone.Substring(6)
                 End If
 
                 If Convert.IsDBNull(dr.Item("STRFAX")) Then
                     lblEPDFax.Text = "404-363-7100"
                 Else
                     EPDFaxNumber = CStr(dr.Item("STRFAX"))
-                    lblEPDFax.Text = EPDFaxNumber.Substring(0, 3) & "-" & EPDFaxNumber.Substring(3, 3) & "-" & EPDFaxNumber.SubstringFrom(6)
+                    lblEPDFax.Text = EPDFaxNumber.Substring(0, 3) & "-" & EPDFaxNumber.Substring(3, 3) & "-" & EPDFaxNumber.Substring(6)
                 End If
 
                 lblEPDEmail.Text = GetNullableString(dr.Item("STREMAILADDRESS"))
@@ -173,7 +173,7 @@ Partial Class TN_Default
                 If Telephone.Length() = 10 Then
                     AreaCode = Left(Telephone, 3)
                     Prefix = Telephone.Substring(3, 3)
-                    TelNbr = Telephone.SubstringFrom(6)
+                    TelNbr = Telephone.Substring(6)
                     TelExt = ""
                 End If
 

--- a/GECO/_Code/StringFunctions.vb
+++ b/GECO/_Code/StringFunctions.vb
@@ -54,13 +54,4 @@ Public Module StringFunctions
         Return s
     End Function
 
-    <Extension>
-    Public Function SubstringFrom(s As String, startIndex As Integer) As String
-        If s Is Nothing OrElse s.Length < startIndex Then
-            Return String.Empty
-        End If
-
-        Return s.Substring(startIndex, s.Length - startIndex)
-    End Function
-
 End Module

--- a/GECO/_Models/People/Person.vb
+++ b/GECO/_Models/People/Person.vb
@@ -33,7 +33,7 @@
             End If
 
             Dim PhoneMain As String = unformattedPhone.Substring(0, 10).Insert(6, "-").Insert(3, "-")
-            Dim PhoneExt As String = unformattedPhone.SubstringFrom(10)
+            Dim PhoneExt As String = unformattedPhone.Substring(10)
 
             Return ConcatNonEmptyStrings(" x ", {PhoneMain, PhoneExt})
         End Function

--- a/GECO/_Models/Permit/PermitApplication.vb
+++ b/GECO/_Models/Permit/PermitApplication.vb
@@ -71,7 +71,7 @@
             value = value.Trim()
 
             If value.Substring(0, 3) = "ERC" Then
-                Return ConcatNonEmptyStrings("-", {value.Substring(0, 3), value.SubstringFrom(3)})
+                Return ConcatNonEmptyStrings("-", {value.Substring(0, 3), value.Substring(3)})
             End If
 
             If Not Char.IsDigit(value(0)) OrElse value.Contains(" ") Then
@@ -80,10 +80,10 @@
 
             If value.Length() = 15 AndAlso IsNumeric(Left(value, 11)) AndAlso Not IsNumeric(value.Substring(11, 1)) Then
                 Return ConcatNonEmptyStrings("-", {value.Substring(0, 4), value.Substring(4, 3), value.Substring(7, 4),
-                                             value.Substring(11, 1), value.Substring(12, 2), value.SubstringFrom(14)})
+                                             value.Substring(11, 1), value.Substring(12, 2), value.Substring(14)})
             End If
 
-            Return ConcatNonEmptyStrings("-", {value.Substring(0, 4), value.Substring(4, 3), value.SubstringFrom(7)})
+            Return ConcatNonEmptyStrings("-", {value.Substring(0, 4), value.Substring(4, 3), value.Substring(7)})
         End Function
 
         Public Function GetPermitFileLink() As String


### PR DESCRIPTION
Method throws `System.ArgumentOutOfRangeException` if length parameter is greater than string length, which happens in this case when the Fax number is not provided (zero-length).

fixes #533 