### PR TITLE
Use Raygun for reporting CSP violations instead of the built-in handler

### DIFF
--- a/GECO/Global.asax.vb
+++ b/GECO/Global.asax.vb
@@ -46,8 +46,4 @@ Public Class Global_asax
     '    ' Fires when the application ends
     'End Sub
 
-    Sub NWebsecHttpHeaderSecurityModule_CspViolationReported(sender As Object, e As CspViolationReportEventArgs)
-        LogToTextFile(e.ViolationReport.ToString)
-    End Sub
-
 End Class

--- a/GECO/Web.configBuilder.xml
+++ b/GECO/Web.configBuilder.xml
@@ -158,7 +158,6 @@
                     <frame-ancestors none="true" />
                     <manifest-src self="true" />
                     <base-uri self="true" />
-                    <report-uri enableBuiltinHandler="true" />
                 </content-Security-Policy>
             </securityHttpHeaders>
         </httpHeaderSecurityModule>


### PR DESCRIPTION
Requires updates to the "web.config" files on the server.

closes #537 